### PR TITLE
Fix reference to mixin file

### DIFF
--- a/Fabric/src/main/resources/publishing.fabric.mod.json
+++ b/Fabric/src/main/resources/publishing.fabric.mod.json
@@ -27,7 +27,7 @@
     ]
   },
   "mixins": [
-    "${modId}.fabric.mixins.json"
+    "${modId}.common.mixins.json"
   ],
 
   "depends": {


### PR DESCRIPTION
Its now called common.mixins.json, not fabric.mixins.json.