### PR TITLE
Add mandatory to NeoForge mods.toml

### DIFF
--- a/1.20.2/NeoForge/src/main/resources/META-INF/mods.toml
+++ b/1.20.2/NeoForge/src/main/resources/META-INF/mods.toml
@@ -23,6 +23,7 @@ config="${modId}.neoforge.mixins.json"
 
 [[dependencies.${ modId }]]
 modId = "neoforge"
+mandatory = true
 type = "required"
 versionRange = "[${minNeoForgeVersion},)"
 ordering = "NONE"
@@ -30,6 +31,7 @@ side = "BOTH"
 
 [[dependencies.${ modId }]]
 modId = "minecraft"
+mandatory = true
 type = "required"
 versionRange = "[${minecraftVersion}]"
 ordering = "NONE"


### PR DESCRIPTION
It seems that NeoForge 1.20.2 requires the `mandatory` property set on dependencies.

Fixes https://github.com/Fuzss/forgeconfigapiport/issues/53 .

Feel free to take this PR or implement it on your own some other way; it's quite a small change.